### PR TITLE
docs(guides/database/full-text-search) update searching multiple columns

### DIFF
--- a/apps/docs/pages/guides/database/full-text-search.mdx
+++ b/apps/docs/pages/guides/database/full-text-search.mdx
@@ -227,6 +227,9 @@ final result = await client
 
 ### Search multiple columns
 
+Right now there is no direct way to use Javascript or Dart to search through multiple columns. A workaround exist where using SQL is required.
+The method involves creating [computed virtual columns](https://postgrest.org/en/stable/api.html#computed-virtual-columns).
+
 To find all `books` where `description` or `title` contain the word `little`:
 
 <Tabs
@@ -245,6 +248,38 @@ from
 where
   to_tsvector(description || ' ' || title) -- concat columns, but be sure to include a space to separate them!
   @@ to_tsquery('little');
+```
+
+</TabPanel>
+<TabPanel id="js" label="JavaScript">
+
+```sql
+CREATE FUNCTION title_description(books) RETURNS text AS $$
+  SELECT $1.title || ' ' || $1.description;
+$$ LANGUAGE SQL;
+```
+
+```js
+const { data, error } = await supabase
+  .from('books')
+  .select()
+  .textSearch('title_description', `little`)
+```
+
+</TabPanel>
+<TabPanel id="dart" label="Dart">
+
+```sql
+CREATE FUNCTION title_description(books) RETURNS text AS $$
+  SELECT $1.title || ' ' || $1.description;
+$$ LANGUAGE SQL;
+```
+
+```dart
+final result = await client
+  .from('books')
+  .select()
+  .textSearch('title_description', "little")
 ```
 
 </TabPanel>


### PR DESCRIPTION
Update searching multiple columns guide (js and dart) with a workaround involving computed virtual columns

Solution by @steve-chahez from this [issue](https://github.com/supabase/postgrest-js/issues/289)

#12508
supabase/postgrest-js/issues/289
